### PR TITLE
Added GitHub and OpenCollective as sponsorship methods

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: emberjs
+open_collective: emberjs


### PR DESCRIPTION
## Description

People can sponsor Ember.js through [GitHub](https://github.com/sponsors/emberjs) and [OpenCollective](https://opencollective.com/emberjs). Let's make the links visible in every repo in the `ember-learn` organization.

Related issue: https://github.com/ember-learn/guides-source/pull/1544


## References

- https://docs.github.com/free-pro-team@latest/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository#about-funding-files